### PR TITLE
interface 관련 코드 중 잘못된 코드 및 설명 수정

### DIFF
--- a/04-interface-and-class/interface-basics.md
+++ b/04-interface-and-class/interface-basics.md
@@ -94,8 +94,8 @@ inteface User {
   readonly height: number;
   /* ... */
 }
-const user: MyReponse<User> = await getUserApiCall(userId);
-user.name; // 타입 시스템은 user.name이 string임을 알 수 있다.
+const res: MyReponse<User> = await getUserApiCall(userId);
+res.data.name; // 타입 시스템은 res.data.name이 string임을 알 수 있다.
 ```
 
 함수 인터페이스의 정의에도 제너릭을 사용 할 수 있다. 이 경우 타입 변수는 매개변수의 앞에 적는다.


### PR DESCRIPTION
# Description
제너릭 인터페이스 설명중에 잘못된 코드가 있어 수정 요청드립니다.

```typescript
const user: MyReponse<User> = await getUserApiCall(userId);
user.name; // 타입 시스템은 user.name이 string임을 알 수 있다.
```

`user`에 들어오는 값은 `myResponse` Type인데 `user.name`으로 `User` type의 property에 바로 접근하는 부분을 수정하였습니다.

제가 드린 변경사항이 아닌 조금 더 간결하게 수정하신다면 아래와 같은 코드도 괜찮을것 같습니다.
```typescript
const user: MyReponse<User> = await getUserApiCall(userId).data;
user.name; // 타입 시스템은 user.name이 string임을 알 수 있다.
```